### PR TITLE
Fixed generic type to prevent possible inferencing issue.

### DIFF
--- a/CalendarPipe.ts
+++ b/CalendarPipe.ts
@@ -46,7 +46,7 @@ export class CalendarPipe implements PipeTransform, OnDestroy {
   private static _initTimer() {
     // initialize the timer
     if (!CalendarPipe._midnight) {
-      CalendarPipe._midnight = new EventEmitter();
+      CalendarPipe._midnight = new EventEmitter<Date>();
       let timeToUpdate = CalendarPipe._getMillisecondsUntilUpdate();
       CalendarPipe._timer = window.setTimeout(() => {
         // emit the current date


### PR DESCRIPTION
When using angular2-moment 0.6.0 in my own project. Following error popped-up every time I start my webpack dev server:

```
webpack: bundle is now VALID.
[default] Checking started in a separate process...
[default] /Users/tang/Git Repositories/issue-webapp/node_modules/angular2-moment/CalendarPipe.ts:49:7 
    Type 'EventEmitter<{}>' is not assignable to type 'EventEmitter<Date>'.
  Type '{}' is not assignable to type 'Date'.
    Property 'toDateString' is missing in type '{}'.
```

This patch fix this issue.
However, I cannot reproduce this issue in angular2-moment project directly. I tried to downgrade typescript related dependencies, modifying the tsconfig.json and tslint.json, etc.

Maybe this issue is related to #25.

