### PR TITLE
fix(TimeAgoPipe): fixes #14 with a new change detection marking approach

### DIFF
--- a/src/TimeAgoPipe.spec.ts
+++ b/src/TimeAgoPipe.spec.ts
@@ -2,6 +2,7 @@ import 'es6-shim';
 import 'reflect-metadata';
 import * as moment from 'moment';
 import {TimeAgoPipe} from './TimeAgoPipe';
+import {WrappedValue} from '@angular/core';
 
 describe('TimeAgoPipe', () => {
   describe('#transform', () => {
@@ -10,28 +11,17 @@ describe('TimeAgoPipe', () => {
     });
 
     it('should transform the current date to "a few seconds ago"', () => {
-      const pipe = new TimeAgoPipe(null);
-      expect(pipe.transform(new Date())).toBe('a few seconds ago');
+      const pipe = new TimeAgoPipe();
+      expect(pipe.transform(new Date())).toEqual(WrappedValue.wrap('a few seconds ago'));
     });
 
     it('should automatically update the text as time passes', () => {
-      const changeDetectorMock = jasmine.createSpyObj('ChangeDetectorRef', ['markForCheck']);
-      const pipe = new TimeAgoPipe(changeDetectorMock);
-      jasmine.clock().install();
-      expect(pipe.transform(new Date())).toBe('a few seconds ago');
-      expect(changeDetectorMock.markForCheck).not.toHaveBeenCalled();
-      jasmine.clock().tick(60000);
-      expect(changeDetectorMock.markForCheck).toHaveBeenCalled();
-    });
-
-    it('should remove all timer when destroyed', () => {
-      const changeDetectorMock = jasmine.createSpyObj('ChangeDetectorRef', ['markForCheck']);
-      const pipe = new TimeAgoPipe(changeDetectorMock);
-      jasmine.clock().install();
-      expect(pipe.transform(new Date())).toBe('a few seconds ago');
-      pipe.ngOnDestroy();
-      jasmine.clock().tick(60000);
-      expect(changeDetectorMock.markForCheck).not.toHaveBeenCalled();
+      const pipe = new TimeAgoPipe(),
+        date = new Date();
+      // First value trigger changes detection and returns a wrapped value
+      expect(pipe.transform(date)).toEqual(WrappedValue.wrap('a few seconds ago'));
+      // Second call will return the cached value, not wrapped
+      expect(pipe.transform(date)).toBe('a few seconds ago');
     });
   });
 });

--- a/src/TimeAgoPipe.ts
+++ b/src/TimeAgoPipe.ts
@@ -1,47 +1,21 @@
 /* angular2-moment (c) 2015, 2016 Uri Shaked / MIT Licence */
 
-import {Pipe, ChangeDetectorRef, PipeTransform, OnDestroy} from '@angular/core';
+import {Pipe, ChangeDetectorRef, PipeTransform, WrappedValue} from '@angular/core';
 import * as moment from 'moment';
 
 // under systemjs, moment is actually exported as the default export, so we account for that
 const momentConstructor: (value?: any) => moment.Moment = (<any>moment).default || moment;
 
 @Pipe({ name: 'amTimeAgo', pure: false })
-export class TimeAgoPipe implements PipeTransform, OnDestroy {
-  private _currentTimer: number;
+export class TimeAgoPipe implements PipeTransform {
+  private previousResult: string = null;
 
-  constructor(private _cdRef: ChangeDetectorRef) {
-  }
-
-  transform(value: Date | moment.Moment, ...args: any[]): string {
-    const momentInstance = momentConstructor(value);
-    this._removeTimer();
-    const timeToUpdate = this._getSecondsUntilUpdate(momentInstance) * 1000;
-    this._currentTimer = window.setTimeout(() => this._cdRef.markForCheck(), timeToUpdate);
-    return momentConstructor(value).from(momentConstructor());
-  }
-
-  ngOnDestroy(): void {
-    this._removeTimer();
-  }
-
-  _removeTimer() {
-    if (this._currentTimer) {
-      window.clearTimeout(this._currentTimer);
-      this._currentTimer = null;
+  transform(value: Date | moment.Moment, ...args: any[]): string | WrappedValue {
+    const result = momentConstructor(value).from(momentConstructor());
+    if (this.previousResult !== result) {
+      this.previousResult = result;
+      return WrappedValue.wrap(result);
     }
-  }
-
-  _getSecondsUntilUpdate(momentInstance: moment.Moment) {
-    const howOld = Math.abs(momentConstructor().diff(momentInstance, 'minute'));
-    if (howOld < 1) {
-      return 1;
-    } else if (howOld < 60) {
-      return 30;
-    } else if (howOld < 180) {
-      return 300;
-    } else {
-      return 3600;
-    }
+    return result;
   }
 }


### PR DESCRIPTION
This fixes issue #14 

This approach doesn't use a timer to mark for changes but simply a value cache and WrappedValue for marking changes ; this way angular change detection never fails.

