### PR TITLE
Exclude automated *.d.ts files from linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   ],
   "scripts": {
     "install_typings": "typings install",
-    "test": "tslint src/*.ts && typings install && tsc && karma start",
+    "test": "tslint src/*.ts --exclude=src/*.d.ts && typings install && tsc && karma start",
     "prepublish": "typings install && tsc --outDir ."
   },
   "repository": {


### PR DESCRIPTION
Proposal to fix #76, as *.d.ts probably do not need linting