### PR TITLE
Explicitly provide the names of exported items rather than export *.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
-export * from './module';
-export * from './CalendarPipe';
-export * from './DateFormatPipe';
-export * from './DurationPipe';
-export * from './FromUnixPipe';
-export * from './TimeAgoPipe';
-export * from './DifferencePipe';
+export { MomentModule } from './module';
+export { CalendarPipe } from './CalendarPipe';
+export { DateFormatPipe } from './DateFormatPipe';
+export { DurationPipe } from './DurationPipe';
+export { FromUnixPipe } from './FromUnixPipe';
+export { TimeAgoPipe } from './TimeAgoPipe';
+export { DifferencePipe } from './DifferencePipe';


### PR DESCRIPTION
RollupJS ( A somewhat popular module bundler, now used by Ionic 2 ) requires all exports to be explicit, then it will try to optimise what's actually included in the bundle.

Sadly it can't handle "export * from".
Should solve issue #81 