### PR TITLE
fix(calender, timeAgo): automatic update broken

### DIFF
--- a/src/CalendarPipe.spec.ts
+++ b/src/CalendarPipe.spec.ts
@@ -8,6 +8,9 @@ class NgZoneMock {
   runOutsideAngular (fn: Function) {
     return fn();
   }
+  run(fn: Function) {
+    return fn();
+  }
 };
 
 describe('CalendarPipe', () => {

--- a/src/CalendarPipe.ts
+++ b/src/CalendarPipe.ts
@@ -30,7 +30,9 @@ export class CalendarPipe implements PipeTransform, OnDestroy {
     // values such as Today will need to be replaced with Yesterday after midnight,
     // so make sure we subscribe to an EventEmitter that we set up to emit at midnight
     this._ngZone.runOutsideAngular(() =>
-      this._midnightSub = CalendarPipe._midnight.subscribe(() => this._cdRef.markForCheck()));
+      this._midnightSub = CalendarPipe._midnight.subscribe(() => {
+        this._ngZone.run(() => this._cdRef.markForCheck());
+      }));
   }
 
   transform(value: Date | moment.Moment, ...args: any[]): any {

--- a/src/TimeAgoPipe.spec.ts
+++ b/src/TimeAgoPipe.spec.ts
@@ -7,6 +7,9 @@ class NgZoneMock {
   runOutsideAngular (fn: Function) {
     return fn();
   }
+  run(fn: Function) {
+    return fn();
+  }
 };
 
 describe('TimeAgoPipe', () => {

--- a/src/TimeAgoPipe.ts
+++ b/src/TimeAgoPipe.ts
@@ -1,6 +1,6 @@
 /* angular2-moment (c) 2015, 2016 Uri Shaked / MIT Licence */
 
-import {Pipe, ChangeDetectorRef, PipeTransform, OnDestroy, NgZone} from '@angular/core';
+import { Pipe, ChangeDetectorRef, PipeTransform, OnDestroy, NgZone } from '@angular/core';
 import * as moment from 'moment';
 
 // under systemjs, moment is actually exported as the default export, so we account for that
@@ -19,7 +19,9 @@ export class TimeAgoPipe implements PipeTransform, OnDestroy {
     const timeToUpdate = this._getSecondsUntilUpdate(momentInstance) * 1000;
     this._currentTimer = this._ngZone.runOutsideAngular(() => {
       if (typeof window !== 'undefined') {
-        return window.setTimeout(() => this._cdRef.markForCheck(), timeToUpdate);
+        return window.setTimeout(() => {
+          this._ngZone.run(() => this._cdRef.markForCheck());
+        }, timeToUpdate);
       }
     });
     return momentConstructor(value).from(momentConstructor(), omitSuffix);


### PR DESCRIPTION
The updates are done outside the Angular zone, so Angular can't tell it the pipe needs to be updated. Fix by calling `markForCheck()` inside the NgZone.