### PR TITLE
feat(*): add `amFromNow` pipe to mimic `moment().fromNow()` behavior

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ calendar.pipe.d.ts
 date-format.pipe.js
 date-format.pipe.js.map
 date-format.pipe.d.ts
+from-now.pipe.js
+from-now.pipe.js.map
+from-now.pipe.d.ts
 from-unix.pipe.js
 from-unix.pipe.js.map
 from-unix.pipe.d.ts

--- a/README.md
+++ b/README.md
@@ -118,6 +118,17 @@ Prints `Last updated: Today at 14:00`
 
 Prints `Last updated: January 24, 2016`
 
+## amFromNow pipe
+
+``` typescript
+@Component({
+  selector: 'app',
+  template: `
+    Expiration: {{ '2016-01-24' | amFromNow }}
+  `
+})
+```
+
 ## amFromUnix pipe
 
 ``` typescript

--- a/src/from-now.pipe.spec.ts
+++ b/src/from-now.pipe.spec.ts
@@ -1,0 +1,25 @@
+import * as moment from 'moment';
+import {FromNowPipe} from './from-now.pipe';
+
+describe('FromNowPipe', () => {
+  describe('#transform', () => {
+    it('should convert provided date to moment string', () => {
+      const pipe = new FromNowPipe();
+      const value = '2007-01-29';
+      const result = pipe.transform(value);
+      expect(result).toEqual(moment(value).fromNow());
+    });
+
+    it('should return undefined when is was provided', () => {
+      const pipe = new FromNowPipe();
+      const result = pipe.transform(undefined);
+      expect(result).toEqual(undefined);
+    });
+
+    it('should return null when is was provided', () => {
+      const pipe = new FromNowPipe();
+      const result = pipe.transform(null);
+      expect(result).toEqual(null);
+    });
+  });
+});

--- a/src/from-now.pipe.ts
+++ b/src/from-now.pipe.ts
@@ -1,0 +1,13 @@
+import {Pipe, ChangeDetectorRef, PipeTransform} from '@angular/core';
+import * as moment from 'moment';
+
+@Pipe({ name: 'amFromNow' })
+export class FromNowPipe implements PipeTransform {
+  transform(value: string): any {
+    if (value == null) {
+      return value;
+    }
+
+    return moment(value).fromNow();
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,8 @@
     "src/date-format.pipe.spec.ts",
     "src/difference.pipe.ts",
     "src/difference.pipe.spec.ts",
+    "src/from-now.pipe.ts",
+    "src/from-now.pipe.spec.ts",
     "src/from-unix.pipe.ts",
     "src/from-unix.pipe.spec.ts",
     "src/duration.pipe.ts",


### PR DESCRIPTION
Closes #45