### PR TITLE
Do not import the whole rxjs library

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,9 +66,7 @@
   },
   "homepage": "https://github.com/urish/angular2-moment#readme",
   "peerDependencies": {
-    "@angular/core": "^2.0.0-rc.5"
-  },
-  "dependencies": {
+    "@angular/core": "^2.0.0-rc.5",
     "moment": "^2.16.0"
   },
   "devDependencies": {
@@ -88,6 +86,7 @@
     "karma-phantomjs-launcher": "1.0.1",
     "karma-sourcemap-loader": "0.3.7",
     "karma-webpack": "1.7.0",
+    "moment": "^2.16.0",
     "phantomjs-prebuilt": "2.1.7",
     "reflect-metadata": "0.1.3",
     "rxjs": "5.0.0-beta.12",

--- a/src/add.pipe.ts
+++ b/src/add.pipe.ts
@@ -5,7 +5,7 @@ import * as moment from 'moment';
 
 @Pipe({ name: 'amAdd' })
 export class AddPipe implements PipeTransform {
-    transform(value: any, ...args: string[]): any {
+    transform(value: any, ...args: any[]): any {
         if (typeof args === 'undefined' || args.length !== 2) {
             throw new Error('AddPipe: missing required arguments');
         }

--- a/src/calendar.pipe.ts
+++ b/src/calendar.pipe.ts
@@ -2,7 +2,7 @@
 
 import {Pipe, ChangeDetectorRef, PipeTransform, EventEmitter, OnDestroy, NgZone} from '@angular/core';
 import * as moment from 'moment';
-import {Subscription} from 'rxjs';
+import {Subscription} from 'rxjs/Subscription';
 
 // under systemjs, moment is actually exported as the default export, so we account for that
 const momentConstructor: (value?: any) => moment.Moment = (<any>moment).default || moment;

--- a/src/subtract.pipe.ts
+++ b/src/subtract.pipe.ts
@@ -5,7 +5,7 @@ import * as moment from 'moment';
 
 @Pipe({ name: 'amSubtract' })
 export class SubtractPipe implements PipeTransform {
-    transform(value: any, ...args: string[]): any {
+    transform(value: any, ...args: any[]): any {
         if (typeof args === 'undefined' || args.length !== 2) {
             throw new Error('SubtractPipe: missing required arguments');
         }


### PR DESCRIPTION
I changed the import of the Subscription from 'rxjs' to 'rxjs/Subscription'. 
This is a best practice with the rxjs library which is huge.

I also fix two typing errors raised by the linter in add and subtract pipes.

Finally, I moved the moment dependency to the devDependencies and peerDependencies. It's the developer responsibility to install the required peer dependencies.

All tests still pass without any error or warning.