### PR TITLE
Add ParsePipe to enable parsing of custom-formatted date string

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,9 @@ subtract.pipe.d.ts
 utc.pipe.js
 utc.pipe.js.map
 utc.pipe.d.ts
+parse.pipe.js
+parse.pipe.js.map
+parse.pipe.d.ts
 *.spec.js
 *.spec.js.map
 *.spec.d.ts

--- a/README.md
+++ b/README.md
@@ -146,6 +146,22 @@ Prints `Last updated: Same Day at 2:00 PM`
 
 Prints `Last updated: January 24, 2016`
 
+## amParse pipe
+
+Parses a custom-formatted date into a moment object that can be used with the other pipes.
+
+``` typescript
+@Component({
+  selector: 'app',
+  template: `
+    Last updated: {{'24/01/2014' | amParse:'DD/MM/YYYY' | amDateFormat:'LL'}}
+  `
+})
+```
+
+Prints `Last updated: January 24, 2016`
+
+
 ## amFromUnix pipe
 
 ``` typescript

--- a/package.json
+++ b/package.json
@@ -49,6 +49,10 @@
     "utc.pipe.js.map",
     "utc.pipe.d.ts",
     "utc.pipe.metadata.json",
+    "parse.pipe.js",
+    "parse.pipe.js.map",
+    "parse.pipe.d.ts",
+    "parse.pipe.metadata.json",
     "CHANGELOG.md"
   ],
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ export { DateFormatPipe } from './date-format.pipe';
 export { DifferencePipe } from './difference.pipe';
 export { DurationPipe } from './duration.pipe';
 export { FromUnixPipe } from './from-unix.pipe';
+export { ParsePipe } from './parse.pipe';
 export { MomentModule } from './moment.module';
 export { SubtractPipe } from './subtract.pipe';
 export { TimeAgoPipe } from './time-ago.pipe';

--- a/src/moment.module.ts
+++ b/src/moment.module.ts
@@ -6,6 +6,7 @@ import { DateFormatPipe } from './date-format.pipe';
 import { DifferencePipe } from './difference.pipe';
 import { DurationPipe } from './duration.pipe';
 import { FromUnixPipe } from './from-unix.pipe';
+import { ParsePipe } from './parse.pipe';
 import { SubtractPipe } from './subtract.pipe';
 import { TimeAgoPipe } from './time-ago.pipe';
 import { UtcPipe } from './utc.pipe';
@@ -17,6 +18,7 @@ const ANGULAR_MOMENT_PIPES = [
   DifferencePipe,
   DurationPipe,
   FromUnixPipe,
+  ParsePipe,
   SubtractPipe,
   TimeAgoPipe,
   UtcPipe

--- a/src/parse.pipe.spec.ts
+++ b/src/parse.pipe.spec.ts
@@ -1,0 +1,40 @@
+import 'es6-shim';
+import 'reflect-metadata';
+import * as moment from 'moment';
+import { DateFormatPipe } from './date-format.pipe';
+import { ParsePipe } from './parse.pipe';
+
+describe('ParsePipe', () => {
+
+  describe('#transform', () => {
+
+    let parsePipe: ParsePipe;
+
+    beforeEach(() => {
+      parsePipe = new ParsePipe();
+    });
+
+    it('should output a moment object for a string date', () => {
+      const dateString = '2015#09#13';
+      const formatInputString = 'YYYY#MM#DD';
+      const parsedMoment = parsePipe.transform(dateString, formatInputString);
+      expect(parsedMoment).toEqual(jasmine.any(moment));
+      expect(parsedMoment.isValid()).toBe(true);
+
+      expect(parsedMoment.year()).toBe(2015);
+      expect(parsedMoment.month()).toBe(8);
+      expect(parsedMoment.date()).toBe(13);
+    });
+
+    it('should be pipeable to amDateFormat', () => {
+      const amDateFormat = new DateFormatPipe();
+      const datetimeString = '01/02/2016';
+      const formatInputString = 'DD/MM/YYYY';
+      const momentFormatString = 'YYYY-MM-DD';
+      const parseOutput = parsePipe.transform(datetimeString, formatInputString);
+      expect(amDateFormat.transform(parseOutput, momentFormatString)).toEqual('2016-02-01');
+    });
+
+  });
+
+});

--- a/src/parse.pipe.ts
+++ b/src/parse.pipe.ts
@@ -1,0 +1,12 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import * as moment from 'moment';
+
+// under systemjs, moment is actually exported as the default export, so we account for that
+const momentConstructor: (value?: any) => moment.Moment = (<any>moment).default || moment;
+
+@Pipe({ name: 'amParse' })
+export class ParsePipe implements PipeTransform {
+  transform(value: string, format: string): moment.Moment {
+    return moment(value, format);
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,6 +28,8 @@
     "src/from-unix.pipe.ts",
     "src/from-unix.pipe.spec.ts",
     "src/index.ts",
+    "src/parse.pipe.ts",
+    "src/parse.pipe.spec.ts",
     "src/moment.module.ts",
     "src/subtract.pipe.ts",
     "src/subtract.pipe.spec.ts",


### PR DESCRIPTION
Added `ParsePipe` to give the same functionality of `amParse` filter from from angular-moment.