### PR TITLE
added lang argument to amDateFormat pipe

### DIFF
--- a/src/date-format.pipe.spec.ts
+++ b/src/date-format.pipe.spec.ts
@@ -7,8 +7,12 @@ describe('DateFormatPipe', () => {
   describe('#transform', () => {
     it('should properly format a date', () => {
       const pipe = new DateFormatPipe();
-      const result = pipe.transform(moment('2016-01-24 01:23:45'), 'MMMM Do YYYY, h:mm:ss a');
-      expect(result).toBe('January 24th 2016, 1:23:45 am');
+
+      const result1 = pipe.transform(moment('2016-01-24 01:23:45'), 'MMMM Do YYYY, h:mm:ss a');
+      expect(result1).toBe('January 24th 2016, 1:23:45 am');
+
+      const result2 = pipe.transform(moment('2016-01-24 14:23:45'), 'MMMM Do YYYY, HH:mm:ss', 'de');
+      expect(result2).toBe('Januar 24. 2016, 14:23:45');
     });
 
     it('should not format empty dates', () => {

--- a/src/date-format.pipe.ts
+++ b/src/date-format.pipe.ts
@@ -10,6 +10,7 @@ const momentConstructor: (value?: any) => moment.Moment = (<any>moment).default 
 export class DateFormatPipe implements PipeTransform {
   transform(value: Date | moment.Moment | string | number, ...args: any[]): string {
     if (!value) return '';
+    if (args[1]) return momentConstructor(value).lang(args[1]).format(args[0]);
     return momentConstructor(value).format(args[0]);
   }
 }


### PR DESCRIPTION
Should close #126 and #120.

If prefered I could also submit a PR for a new pipe that would change language like:
```{{'24/01/2014' | amLang:'de' | amDateFormat:'LL'}}```

Let me know what you think!