### PR TITLE
Remove node_modules from compiled version

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
     "test:debug": "node --inspect-brk --inspect ./node_modules/jest/bin/jest.js --runInBand",
-    "prepublish": "ngc && copyfiles -f src/*.js src/*.js.map src/*.d.ts src/*.metadata.json ."
+    "prepublish": "ngc && rimraf -- \"./compiled/node_modules\" && copyfiles -f src/*.js src/*.js.map src/*.d.ts src/*.metadata.json ."
   },
   "repository": {
     "type": "git",
@@ -111,7 +111,8 @@
     "tslint": "3.15.1",
     "typescript": "^2.1.6",
     "webpack": "1.13.2",
-    "zone.js": "^0.7.2"
+    "zone.js": "^0.7.2",
+    "rimraf": "^2.6.2"
   },
   "jest": {
     "roots": [


### PR DESCRIPTION
The compiled version, which is pushed to npm, contains a bundled version of `moment`, which makes it impossible to set the local from outside with 

```
import * as moment  from 'moment';
moment.locale('de');
```

because the internal `moment` version is not identical with the version you import from else where (see https://github.com/urish/angular2-moment/issues/149).

To fix that problem I remove the `node_modules` folder from the compiled version. A little disadvantage is that you have to specify `moment` in you project `package.json` as `dependencies` which means probably an breaking change.