### PR TITLE
amTimeAgo pipe updates it's output when locale changes

### DIFF
--- a/src/time-ago.pipe.spec.ts
+++ b/src/time-ago.pipe.spec.ts
@@ -3,6 +3,7 @@ import 'reflect-metadata';
 import { NgZone } from '@angular/core';
 import { TimeAgoPipe } from './time-ago.pipe';
 import * as moment from 'moment';
+import 'moment/min/locales';
 
 declare var global: any;
 
@@ -63,6 +64,22 @@ describe('TimeAgoPipe', () => {
       expect(pipe.transform(new Date(0))).toBe('46 years ago');
       expect(pipe.transform(moment())).toBe('a few seconds ago');
       expect(pipe.transform(moment(0))).toBe('46 years ago');
+    });
+
+    it('should update the text when moment locale changes', () => {
+      const changeDetectorMock = { markForCheck: jest.fn() };
+      const pipe = new TimeAgoPipe(changeDetectorMock as any, new NgZoneMock() as NgZone);
+      fakeDate('2016-05-01');
+      expect(pipe.transform(moment(0))).toBe('46 years ago');
+      expect(pipe.transform(moment(0).locale('pl'))).toBe('46 lat temu');
+    });
+
+    it('should reset language when localized moment changes to Date', () => {
+      const changeDetectorMock = { markForCheck: jest.fn() };
+      const pipe = new TimeAgoPipe(changeDetectorMock as any, new NgZoneMock() as NgZone);
+      fakeDate('2016-05-01');
+      expect(pipe.transform(moment(0).locale('pl'))).toBe('46 lat temu');
+      expect(pipe.transform(new Date(0))).toBe('46 years ago');
     });
 
     it('should update the text when the date instance time is updated', () => {

--- a/src/time-ago.pipe.ts
+++ b/src/time-ago.pipe.ts
@@ -13,6 +13,7 @@ export class TimeAgoPipe implements PipeTransform, OnDestroy {
   private lastTime: Number;
   private lastValue: Date | moment.Moment;
   private lastOmitSuffix: boolean;
+  private lastLocale?: string;
   private lastText: string;
 
   constructor(private cdRef: ChangeDetectorRef, private ngZone: NgZone) {
@@ -23,6 +24,7 @@ export class TimeAgoPipe implements PipeTransform, OnDestroy {
       this.lastTime = this.getTime(value);
       this.lastValue = value;
       this.lastOmitSuffix = omitSuffix;
+      this.lastLocale = this.getLocale(value);
       this.removeTimer();
       this.createTimer();
       this.lastText = momentConstructor(value).from(momentConstructor(), omitSuffix);
@@ -80,7 +82,9 @@ export class TimeAgoPipe implements PipeTransform, OnDestroy {
   }
 
   private hasChanged(value: Date | moment.Moment, omitSuffix?: boolean) {
-    return this.getTime(value) !== this.lastTime || omitSuffix !== this.lastOmitSuffix;
+    return this.getTime(value) !== this.lastTime
+      || this.getLocale(value) !== this.lastLocale
+      || omitSuffix !== this.lastOmitSuffix;
   }
 
   private getTime(value: Date | moment.Moment) {
@@ -91,5 +95,9 @@ export class TimeAgoPipe implements PipeTransform, OnDestroy {
     } else {
       return momentConstructor(value).valueOf();
     }
+  }
+
+  private getLocale(value: Date | moment.Moment): string {
+    return moment.isMoment(value) ? value.locale() : null;
   }
 }


### PR DESCRIPTION
`TimeAgoPipe` updates it's _output_ only when it detects it's _input_ has changed.
To do so, it does extract and compare a timestamp (milliseconds).
The output, however, depends not only on milliseconds, but also on locale. That was not taken into account.

I hereby propose a pull request that fixes this. 
Locale setting for current _moment_ instance is now considered. If you change locale globally (`moment.locale(...)`) you will need to make sure new _moment_ instance will trigger the pipe. I consider this the most predictable behaviour.

Please let me know your view, or suggest further changes. Thank you!

Resolves #172.